### PR TITLE
Enable DELETE key for deleting a note

### DIFF
--- a/src/com/pinktwins/elephant/ElephantWindow.java
+++ b/src/com/pinktwins/elephant/ElephantWindow.java
@@ -548,6 +548,7 @@ public class ElephantWindow extends JFrame {
 							noteList.changeSelection(1, e);
 							break;
 						case KeyEvent.VK_BACK_SPACE:
+						case KeyEvent.VK_DELETE:
 							deleteSelectedNote();
 							break;
 						}


### PR DESCRIPTION
Under Windows, pressing the `delete` key is more common than backspace to delete something.
