### PR TITLE
Switch to sans serif font for previews

### DIFF
--- a/src/com/pinktwins/elephant/HtmlPane.java
+++ b/src/com/pinktwins/elephant/HtmlPane.java
@@ -5,6 +5,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.logging.Logger;
 
+import javax.swing.JEditorPane;
 import javax.swing.JTextPane;
 import javax.swing.text.Document;
 import javax.swing.text.html.HTMLDocument;
@@ -30,6 +31,8 @@ public class HtmlPane extends JTextPane {
 			if (doc instanceof HTMLDocument) {
 				d = (HTMLDocument) doc;
 				d.setBase(baseUrl);
+				// hint by http://stackoverflow.com/a/19785465/873282
+				this.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, true);
 			}
 		} catch (MalformedURLException e) {
 			LOG.severe("Fail: " + e);

--- a/src/com/pinktwins/elephant/NoteItem.java
+++ b/src/com/pinktwins/elephant/NoteItem.java
@@ -15,6 +15,7 @@ import java.util.logging.Logger;
 
 import javax.imageio.ImageIO;
 import javax.swing.BorderFactory;
+import javax.swing.JEditorPane;
 import javax.swing.JPanel;
 import javax.swing.JTextPane;
 import javax.swing.text.BadLocationException;
@@ -141,6 +142,8 @@ abstract class NoteItem extends JPanel implements Comparable<NoteItem>, MouseLis
 		if (note.isMarkdown()) {
 			String contents = note.contents();
 			String html = NoteEditor.pegDown.markdownToHtml(contents);
+			// hint by http://stackoverflow.com/a/19785465/873282
+			preview.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, true);
 			preview.setText(html);
 		} else {
 			CustomEditor.setTextRtfOrPlain(preview, getContentPreview());


### PR DESCRIPTION
This adresses https://github.com/jusu/Elephant/issues/9#issuecomment-73423404. A monospaced font for the editing mode is more difficult as `com.pinktwins.elephant.ElephantWindow.fontEditor` defaults to Arial and there doesn't seem an easy way to use just a nice monospace font (see http://stackoverflow.com/questions/11020978/monospaced-font-symbols-for-jtextpane).
