### PR TITLE
Added creation date to markdown notes. Issue #29

### DIFF
--- a/src/com/pinktwins/elephant/ElephantWindow.java
+++ b/src/com/pinktwins/elephant/ElephantWindow.java
@@ -96,7 +96,7 @@ public class ElephantWindow extends JFrame {
 
 	private JMenuBar menuBar;
 	private JMenuItem iUndo, iRedo, iSaveSearch;
-	private JCheckBoxMenuItem iCard, iSnippet;
+	private JCheckBoxMenuItem iCard, iSnippet, iRecentNotes;
 
 	private static final Image elephantIcon;
 
@@ -335,6 +335,13 @@ public class ElephantWindow extends JFrame {
 		}
 	};
 
+	ActionListener showRecentNotesAction = new ActionListener() {
+		@Override
+		public void actionPerformed(ActionEvent e) {
+			sideBar.toggleRecentNotes();
+		}
+	};
+	
 	ActionListener settingsAction = new ActionListener() {
 		@Override
 		public void actionPerformed(ActionEvent e) {
@@ -932,10 +939,23 @@ public class ElephantWindow extends JFrame {
 			iSnippet.setSelected(true);
 			break;
 		}
-
+		
 		view.add(menuItem("Show All Notes", KeyEvent.VK_A, menuMask | KeyEvent.SHIFT_DOWN_MASK, showAllNotesAction));
 		view.add(menuItem("Jump to Notebook", KeyEvent.VK_J, menuMask, jumpToNotebookAction));
 
+		view.addSeparator();
+		iRecentNotes = new JCheckBoxMenuItem("Recent Notes");
+		iRecentNotes.addActionListener(showRecentNotesAction);
+		view.add(iRecentNotes);
+		switch (Elephant.settings.getRecentNotesMode()) {
+		case SHOW:
+			iRecentNotes.setSelected(true);
+			break;
+		case HIDE:
+			iRecentNotes.setSelected(false);
+			break;
+		}
+		
 		JMenu note = new JMenu("Note");
 		note.add(menuItem("Edit Note Title", KeyEvent.VK_L, menuMask, editTitleAction));
 		note.add(menuItem("Edit Note Tags", KeyEvent.VK_QUOTE, menuMask, editTagsAction));

--- a/src/com/pinktwins/elephant/NoteEditor.java
+++ b/src/com/pinktwins/elephant/NoteEditor.java
@@ -164,7 +164,7 @@ public class NoteEditor extends BackgroundPanel implements EditorEventListener {
 	TagEditorPane tagPane;
 	BackgroundPanel topShadow;
 	JButton currNotebook, trash;
-	JLabel noteCreated, noteUpdated;
+	JLabel noteCreated, noteUpdated, noteAccessed;
 	BorderLayout areaHolderLayout;
 
 	private class DividedPanel extends BackgroundPanel {
@@ -301,9 +301,15 @@ public class NoteEditor extends BackgroundPanel implements EditorEventListener {
 		noteUpdated.setBorder(BorderFactory.createEmptyBorder(0, 4, 4, 20));
 		noteUpdated.setForeground(ElephantWindow.colorTitleButton);
 		noteUpdated.setFont(ElephantWindow.fontMedium);
+		
+		noteAccessed = new JLabel("Accesesd: xxxxxx");
+		noteAccessed.setBorder(BorderFactory.createEmptyBorder(0, 4, 4, 20));
+		noteAccessed.setForeground(ElephantWindow.colorTitleButton);
+		noteAccessed.setFont(ElephantWindow.fontMedium);
 
 		toolsBot.add(noteCreated);
 		toolsBot.add(noteUpdated);
+		toolsBot.add(noteAccessed);
 
 		tools.add(toolsTop, BorderLayout.NORTH);
 		tools.add(toolsBot, BorderLayout.SOUTH);
@@ -603,8 +609,7 @@ public class NoteEditor extends BackgroundPanel implements EditorEventListener {
 
 		trash.setVisible(!nb.folder().equals(Vault.getInstance().getTrash()));
 
-		noteCreated.setText("Created: " + note.createdStr());
-		noteUpdated.setText("Updated: " + note.updatedStr());
+		reloadDates();
 
 		caretChanged(editor.getTextPane());
 
@@ -621,10 +626,21 @@ public class NoteEditor extends BackgroundPanel implements EditorEventListener {
 	}
 
 	private void reloadDates() {
-		noteCreated.setText("Created: " + currentNote.createdStr());
-		noteUpdated.setText("Updated: " + currentNote.updatedStr());
-	}
+		String createdStr = currentNote.createdStr();
+		String updatedStr = currentNote.updatedStr();
+		String accessedStr = currentNote.accessedStr();
 
+		noteCreated.setText("Created: " + createdStr);
+		noteUpdated.setText("Updated: " + updatedStr);
+		
+		if (accessedStr != "" && !accessedStr.equals(updatedStr) && !accessedStr.equals(createdStr))
+			noteAccessed.setText("Accessed: " + accessedStr);
+		else{
+			noteAccessed.setText("");
+			noteAccessed.setVisible(false);
+		}
+	}
+	
 	public void focusQuickLook() {
 		for (Object o : attachments.keySet()) {
 			if (o instanceof FileAttachment) {

--- a/src/com/pinktwins/elephant/NoteItem.java
+++ b/src/com/pinktwins/elephant/NoteItem.java
@@ -139,16 +139,6 @@ abstract class NoteItem extends JPanel implements Comparable<NoteItem>, MouseLis
 		preview.setBounds(0, 0, 176, 138);
 		preview.addMouseListener(this);
 
-		if (note.isMarkdown()) {
-			String contents = note.contents();
-			String html = NoteEditor.pegDown.markdownToHtml(contents);
-			// hint by http://stackoverflow.com/a/19785465/873282
-			preview.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, true);
-			preview.setText(html);
-		} else {
-			CustomEditor.setTextRtfOrPlain(preview, getContentPreview());
-		}
-
 		// time
 		String ts = "";
 		Color col = ElephantWindow.colorGreen;
@@ -171,13 +161,24 @@ abstract class NoteItem extends JPanel implements Comparable<NoteItem>, MouseLis
 		if (now - note.lastModified() > time_24h * 30) {
 			col = ElephantWindow.colorBlue;
 		}
-
+		
 		Style style = preview.addStyle("timestampStyle", null);
 		StyleConstants.setForeground(style, col);
-		try {
-			preview.getDocument().insertString(0, ts + " ", style);
-		} catch (BadLocationException e) {
-			LOG.severe("Fail: " + e);
+		
+		if (note.isMarkdown()) {
+			String htmlts = "<p style='margin:0;padding:0;color:" + String.format("#%02x%02x%02x", col.getRed(), col.getGreen(), col.getBlue()) +"'>" + ts + "</p>\n";
+			String contents = htmlts + note.contents();
+			String html = NoteEditor.pegDown.markdownToHtml(contents);
+			// hint by http://stackoverflow.com/a/19785465/873282
+			preview.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, true);
+			preview.setText(html);
+		} else {
+			CustomEditor.setTextRtfOrPlain(preview, getContentPreview());
+			try {
+				preview.getDocument().insertString(0, ts + " ", style);
+			} catch (BadLocationException e) {
+				LOG.severe("Fail: " + e);
+			}
 		}
 
 		previewPane.add(preview);

--- a/src/com/pinktwins/elephant/NoteItem.java
+++ b/src/com/pinktwins/elephant/NoteItem.java
@@ -161,7 +161,7 @@ abstract class NoteItem extends JPanel implements Comparable<NoteItem>, MouseLis
 		if (now - note.lastModified() > time_24h * 30) {
 			col = ElephantWindow.colorBlue;
 		}
-		
+
 		Style style = preview.addStyle("timestampStyle", null);
 		StyleConstants.setForeground(style, col);
 		

--- a/src/com/pinktwins/elephant/Sidebar.java
+++ b/src/com/pinktwins/elephant/Sidebar.java
@@ -12,6 +12,7 @@ import com.google.common.eventbus.Subscribe;
 import com.pinktwins.elephant.data.Note;
 import com.pinktwins.elephant.data.Notebook;
 import com.pinktwins.elephant.data.RecentNotes;
+import com.pinktwins.elephant.data.Settings;
 import com.pinktwins.elephant.data.Shortcuts;
 import com.pinktwins.elephant.eventbus.RecentNotesChangedEvent;
 import com.pinktwins.elephant.eventbus.ShortcutsChangedEvent;
@@ -33,6 +34,28 @@ public class Sidebar extends BackgroundPanel {
 
 	SideBarList shortcutList, recentList, navigationList;
 
+	public static enum RecentNotesModes {
+		SHOW,
+		HIDE
+	};
+	
+	private RecentNotesModes recentMode = RecentNotesModes.SHOW;
+	
+	public void toggleRecentNotes(){
+		switch (recentMode) {
+		case SHOW:
+			recentList.setVisible(false);
+			recentMode = RecentNotesModes.HIDE;
+			break;
+		case HIDE:
+			recentList.setVisible(true);
+			recentMode = RecentNotesModes.SHOW;
+			break;
+		}
+		
+		Elephant.settings.set(Settings.Keys.RECENT_SHOW, recentMode.toString());
+	}
+	
 	static {
 		Iterator<Image> i = Images.iterator(new String[] { "sidebar", "sidebarDivider" });
 		tile = i.next();
@@ -80,6 +103,18 @@ public class Sidebar extends BackgroundPanel {
 		add(p1, BorderLayout.CENTER);
 		p1.add(p2, BorderLayout.CENTER);
 		p2.add(p3, BorderLayout.CENTER);
+		
+		// recent notes toggle settings
+		recentMode = Elephant.settings.getRecentNotesMode();
+		
+		switch (recentMode) {
+		case SHOW:
+			recentList.setVisible(true);
+			break;
+		case HIDE:
+			recentList.setVisible(false);
+			break;
+		}
 	}
 
 	public void selectNavigation(int n) {

--- a/src/com/pinktwins/elephant/data/Note.java
+++ b/src/com/pinktwins/elephant/data/Note.java
@@ -3,6 +3,10 @@ package com.pinktwins.elephant.data;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -12,7 +16,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
-
+import java.util.regex.Pattern;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultStyledDocument;
 
@@ -194,6 +198,18 @@ public class Note implements Comparable<Note> {
 
 	public String updatedStr() {
 		return df.print(lastModified());
+	}
+	
+	public String accessedStr(){
+		BasicFileAttributes basicFileAttributes;
+		try{
+	    basicFileAttributes = Files.getFileAttributeView(file.toPath(), BasicFileAttributeView.class).readAttributes();
+	    } catch (IOException e){
+	    	return "";
+	    }
+		// Check if millis is 0, if so, last accessed time is not supported 
+		long millis = basicFileAttributes.lastAccessTime().toMillis();
+	    return millis > 0 ? df.print(basicFileAttributes.lastAccessTime().toMillis()) : "";
 	}
 
 	private void readInfo() {
@@ -394,7 +410,6 @@ public class Note implements Comparable<Note> {
 			setMeta("tagNames", StringUtils.join(tagNames, ","));
 			reload();
 		}
-
 	}
 
 	private String ts() {

--- a/src/com/pinktwins/elephant/data/Settings.java
+++ b/src/com/pinktwins/elephant/data/Settings.java
@@ -8,6 +8,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import com.pinktwins.elephant.NoteList.ListModes;
+import com.pinktwins.elephant.Sidebar.RecentNotesModes;
 import com.pinktwins.elephant.util.IOUtil;
 
 public class Settings {
@@ -15,7 +16,7 @@ public class Settings {
 	private static final Logger LOG = Logger.getLogger(Settings.class.getName());
 
 	public static enum Keys {
-		DEFAULT_NOTEBOOK("defaultNotebook"), VAULT_FOLDER("noteFolder"), USE_LUCENE("useLucene"), NOTELIST_MODE("noteListMode"), AUTOBULLET("autoBullet");
+		DEFAULT_NOTEBOOK("defaultNotebook"), VAULT_FOLDER("noteFolder"), USE_LUCENE("useLucene"), NOTELIST_MODE("noteListMode"), AUTOBULLET("autoBullet"), RECENT_SHOW("showRecent");
 
 		private final String str;
 
@@ -146,6 +147,25 @@ public class Settings {
 		return ListModes.CARDVIEW;
 	}
 
+	public RecentNotesModes getRecentNotesMode() {
+		String mode = getString(Keys.RECENT_SHOW);
+		
+		if (mode.isEmpty()) {
+			return RecentNotesModes.SHOW;
+		}
+
+		if (RecentNotesModes.SHOW.toString().equals(mode)) {
+			return RecentNotesModes.SHOW;
+		}
+
+		if (RecentNotesModes.HIDE.toString().equals(mode)) {
+			return RecentNotesModes.HIDE;
+		}
+
+		LOG.severe("Unknown recentNotesMode: " + mode);
+		return RecentNotesModes.SHOW;
+	}
+	
 	public boolean getAutoBullet() {
 		if (!has(Keys.AUTOBULLET)) {
 			return true;


### PR DESCRIPTION
Fixed issue #29 where the creation date wouldn't show for markdown note previews.

Also with a different implementation https://github.com/lolsteve/Elephant/tree/markup_date
but I think this one is nicer.

![screen shot 2015-11-25 at 8 45 24 pm](https://cloud.githubusercontent.com/assets/729707/11415254/85f14144-93b5-11e5-8976-d5a7b4f81f47.png)
![screen shot 2015-11-25 at 8 51 12 pm](https://cloud.githubusercontent.com/assets/729707/11415317/533ab702-93b6-11e5-8aee-ab34ec3b57e8.png)
