### PR TITLE
Added external Stylesheet for HtmlPane

### DIFF
--- a/src/com/pinktwins/elephant/HtmlPane.java
+++ b/src/com/pinktwins/elephant/HtmlPane.java
@@ -9,6 +9,7 @@ import javax.swing.JEditorPane;
 import javax.swing.JTextPane;
 import javax.swing.text.Document;
 import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.HTMLEditorKit;
 
 public class HtmlPane extends JTextPane {
 
@@ -37,6 +38,10 @@ public class HtmlPane extends JTextPane {
 		} catch (MalformedURLException e) {
 			LOG.severe("Fail: " + e);
 		}
+
+		HTMLEditorKit kit = new HTMLEditorKit();
+		this.setEditorKit(kit);
+		HtmlPaneStylesheet.getInstance().addStylesheet(kit);
 
 		addMouseListener(new HtmlPaneMouseListener(this, base, onTerminalClick));
 	}

--- a/src/com/pinktwins/elephant/HtmlPaneStylesheet.java
+++ b/src/com/pinktwins/elephant/HtmlPaneStylesheet.java
@@ -1,0 +1,74 @@
+package com.pinktwins.elephant;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.swing.text.html.HTMLEditorKit;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.Validate;
+
+import com.pinktwins.elephant.data.Settings;
+
+public class HtmlPaneStylesheet {
+
+	// private StyleSheet stylesheet = null;
+	private List<String> rules = new ArrayList<String>();
+
+	private static HtmlPaneStylesheet instance = null;
+
+	private static final Logger LOG = Logger.getLogger(HtmlPaneStylesheet.class.getName());
+
+	public static HtmlPaneStylesheet getInstance() {
+		String property = System.getenv("elephant.alwaysReadStylesheet");
+		boolean alwaysLoad = Boolean.TRUE.toString().equals(property);
+		if (instance == null || alwaysLoad) {
+			instance = new HtmlPaneStylesheet();
+		}
+		return instance;
+	}
+
+	private HtmlPaneStylesheet() {
+		createStylesheet();
+	}
+
+	private void createStylesheet() {
+		String string = Elephant.settings.getString(Settings.Keys.VAULT_FOLDER);
+		string = string + File.separator + "style.css";
+		File file = new File(string);
+		if (file.exists() && file.canRead()) {
+			try {
+				String styleString = IOUtils.toString(new FileInputStream(file));
+				/*
+				 * Add a Stylesheet-Parser, but first all simple, every Style in one line!
+				 */
+				String lines[] = styleString.split("\\r?\\n");
+				for (String line : lines) {
+					// stylesheet.addRule(line);
+					rules.add(line);
+				}
+			} catch (FileNotFoundException e) {
+				LOG.log(Level.WARNING, string + " not found", e);
+			} catch (IOException e) {
+				LOG.log(Level.WARNING, "error reading style.css", e);
+			}
+		}
+	}
+
+	public void addStylesheet(HTMLEditorKit kit) {
+		Validate.notNull(kit);
+		if (!rules.isEmpty()) {
+			for (String rule : rules) {
+				kit.getStyleSheet().addRule(rule);
+			}
+			// kit.getStyleSheet().addStyleSheet(stylesheet);
+		}
+	}
+
+}


### PR DESCRIPTION
Added the possibility to create a very simple Textfile to style the HtmlPane.
You can create a a style.css file in the Notebook-Folder with Styles for the JEditorPane.
Every Style must be in one line, without empty rows or comments.

sample style.css content:
h1 {font-size: 16px;font-weight:bold}
h2 {font-size: 14px;font-weight:bold}
h3 {font-size: 12px;font-weight:bold}
h4 {font-size: 10px;font-weight:bold}
table {font-size: 12px}
body {font-size: 12px}
p {font-size: 12px}
ol {font-size: 12px}
li {font-size: 12px}
ul {font-size: 12px}
code {font-family: 'Courier New', Courier, monospace, sans-serif; font-size: 12px; text-align: left;color: #102040;}
pre {background:#c0d0f0; font-size: 12px;margin-top: 15px; padding-left: 10px; padding-bottom:5px; padding-top:5px;border-left: 15px solid #ccc;overflow: auto;width: 93%;}
