### PR TITLE
Refactoring starting dialog and creating selected base directory if it doesn't exist.

### DIFF
--- a/src/com/pinktwins/elephant/NoteEditor.java
+++ b/src/com/pinktwins/elephant/NoteEditor.java
@@ -864,6 +864,7 @@ public class NoteEditor extends BackgroundPanel implements EditorEventListener {
 			String noteFilename = currentNote.file().getName();
 			try {
 				noteFilename = URLEncoder.encode(noteFilename, "UTF-8");
+				noteFilename = noteFilename.replace("+",  "%20");
 			} catch (UnsupportedEncodingException e) {
 				LOG.severe("Fail: " + e);
 			}

--- a/src/com/pinktwins/elephant/SaveChanges.java
+++ b/src/com/pinktwins/elephant/SaveChanges.java
@@ -128,6 +128,8 @@ public class SaveChanges {
 						try {
 							oldPath = URLEncoder.encode(oldPath, "UTF-8");
 							newPath = URLEncoder.encode(newPath, "UTF-8");
+							oldPath = oldPath.replace("+", "%20");
+							newPath = newPath.replace("+", "%20");
 						} catch (UnsupportedEncodingException e) {
 							LOG.severe("Fail: " + e);
 						}


### PR DESCRIPTION
Cleaning up code in `Start.java` by splitting tasks into their own functions and handling unneeded nesting of blocks. Also making it so a user can specific a non-existent directory through the file chooser which will be created for them, both in the case where the `Elephant` sub-directory is created as well as when it is not. These changes were inspired by https://github.com/jusu/Elephant/issues/93 and in particular the third suggestion that we handle a user typing in a non-existent folder.

To facilitate verifying my changes I encourage testing the following scenarios:

- Choosing an existing folder with `createElephantFolderCheckBox` checked should result in an `Elephant` folder being created under that folder.
- Typing in a non-existent folder with `createElephantFolderCheckBox` checked should result in the non-existent folder being created and the `Elephant` folder being created under it.
- Choosing an existing folder with `createElephantFolderCheckBox` unchecked should not result in an `Elephant` folder being created under that folder.
- Choosing a non-existent folder with `createElephantFolderCheckBox` unchecked should result in the non-existent folder being created and should not result in an `Elephant` folder being created under it.

Eventually, I might also look into the second suggestion from https://github.com/jusu/Elephant/issues/93 which brings up the point that menu items dependent on initial setup, such as creating new notes, should be greyed out to prevent ill defined behavior.
