### PR TITLE
Issue 107: Create the lucene directory inside the elephant vault.

### DIFF
--- a/src/com/pinktwins/elephant/data/Vault.java
+++ b/src/com/pinktwins/elephant/data/Vault.java
@@ -3,6 +3,7 @@ package com.pinktwins.elephant.data;
 import java.awt.EventQueue;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -213,7 +214,7 @@ public class Vault implements WatchDirListener {
 	}
 
 	public String getLuceneIndexPath() {
-		return Elephant.settings.userHomePath() + File.separator + ".com.pinktwins.elephant.searchIndex";
+		return Paths.get(getHome().getAbsolutePath(), ".searchIndex").toString();
 	}
 
 	public void saveNewTag(final Tag tag) {


### PR DESCRIPTION
The lucene index is currently created in the home directory. The search index can contain data from multiple note locations which make the notes available to other locations when switching. 

This simple solution is to create a .searchIndex/ subdirectory inside the notes vault. Each notes location will have its own separate lucene directory.