### PR TITLE
fix/issue-107 Prevent lucene corrupting vault index when switching

### DIFF
--- a/src/com/pinktwins/elephant/data/SearchIndexer.java
+++ b/src/com/pinktwins/elephant/data/SearchIndexer.java
@@ -41,6 +41,15 @@ public class SearchIndexer {
 		}
 	}
 
+	public void stop() {
+		if(luceneIndex != null) {
+			// Stop lucene indexing.
+			luceneIndex.commit();
+			luceneIndex = null;
+			useLucene = false;
+		}
+	}
+
 	public boolean ready() {
 		return isReady;
 	}

--- a/src/com/pinktwins/elephant/data/Settings.java
+++ b/src/com/pinktwins/elephant/data/Settings.java
@@ -1,17 +1,14 @@
 package com.pinktwins.elephant.data;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.logging.Logger;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import com.google.common.io.Files;
 import com.pinktwins.elephant.NoteList.ListModes;
 import com.pinktwins.elephant.Sidebar.RecentNotesModes;
 import com.pinktwins.elephant.util.IOUtil;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Logger;
 
 public class Settings {
 
@@ -165,6 +162,10 @@ public class Settings {
 	private String homeDir;
 	private JSONObject map;
 
+	/**
+	 * Get the {@link File} containing the persisted Elephant settings.
+	 * @return File containing the Elephant settings.
+	 */
 	public File settingsFile() {
 		return new File(homeDir + File.separator + ".com.pinktwins.elephant.settings");
 	}
@@ -288,12 +289,14 @@ public class Settings {
 		return this;
 	}
 
+	/**
+	 * Persist the Elephant settings to the file system.
+	 */
 	private void save() {
-		try {
-			Files.write(map.toString(4), settingsFile(), Charset.forName("UTF-8"));
-		} catch (IOException e) {
-			LOG.severe("Fail: " + e);
-		} catch (JSONException e) {
+		final File settingsFile = settingsFile();
+		try (Writer settingsWriter = new OutputStreamWriter(new FileOutputStream(settingsFile), StandardCharsets.UTF_8)) {
+			settingsWriter.write(map.toString(4));
+		} catch (IOException | JSONException e) {
 			LOG.severe("Fail: " + e);
 		}
 	}

--- a/src/com/pinktwins/elephant/data/Vault.java
+++ b/src/com/pinktwins/elephant/data/Vault.java
@@ -3,6 +3,7 @@ package com.pinktwins.elephant.data;
 import java.awt.EventQueue;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -106,12 +107,21 @@ public class Vault implements WatchDirListener {
 		return trash;
 	}
 
+	/**
+	 * Prepare the vault directory, see that everything is present.
+	 * <ul>
+	 *     <li>Create the Trash notebook.</li>
+	 *     <li>Create a Notebook instance for all visible directories in the vault base directory.</li>
+	 * </ul>
+	 */
 	public void populate() {
 		home = new File(HOME);
 
+		// The trash directory should always be there.
 		trash = new File(home.getAbsolutePath() + File.separator + "Trash");
 		trash.mkdirs();
 
+		// Scan the vault directory for notebooks.
 		synchronized (Search.lockObject) {
 			for (File f : home.listFiles()) {
 				if (f.isDirectory() && f.getName().charAt(0) != '.') {
@@ -213,7 +223,7 @@ public class Vault implements WatchDirListener {
 	}
 
 	public String getLuceneIndexPath() {
-		return Elephant.settings.userHomePath() + File.separator + ".com.pinktwins.elephant.searchIndex";
+		return Paths.get(getHome().getAbsolutePath(), ".searchIndex").toString();
 	}
 
 	public void saveNewTag(final Tag tag) {


### PR DESCRIPTION
Create a separate .searchIndex lucene folder local in the vault to prevent different vaults using the same search index.

Stop the indexer before changing the vault location.
It is to make sure the indexer does not write data from the current vault to the new location.

Replace deprecated code that saves the settings file with standard Java library method.